### PR TITLE
Rebuild missing zip files

### DIFF
--- a/archive.tf
+++ b/archive.tf
@@ -1,5 +1,5 @@
-# Generates a filename for the zip archive based on the contents of source_dir
-# and source_file. The filename will change when the source code changes.
+# Generates a filename for the zip archive based on the contents of the files
+# in source_path. The filename will change when the source code changes.
 data "external" "archive" {
   program = ["python", "${path.module}/hash.py"]
 
@@ -17,5 +17,20 @@ resource "null_resource" "archive" {
 
   provisioner "local-exec" {
     command = "${lookup(data.external.archive.result, "build_command")}"
+  }
+}
+
+# Check that the null_resource.archive file has been built. This will rebuild
+# it if missing. This is used to catch situations where the Terraform state
+# does not match the Lambda function in AWS, e.g. after someone manually
+# deletes the Lambda function. If the file is rebuilt here, the build
+# output is unfortunately invisible.
+data "external" "built" {
+  program = ["python", "${path.module}/built.py"]
+
+  query = {
+    build_command = "${lookup(data.external.archive.result, "build_command")}"
+    filename_old  = "${lookup(null_resource.archive.triggers, "filename")}"
+    filename_new  = "${lookup(data.external.archive.result, "filename")}"
   }
 }

--- a/built.py
+++ b/built.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python2
+
+from __future__ import print_function
+
+import json
+import os
+import subprocess
+import sys
+
+
+# Parse the query.
+query = json.load(sys.stdin)
+build_command = query['build_command']
+filename_old = query['filename_old']
+filename_new = query['filename_new']
+
+# If the old filename (from the Terraform state) matches the new filename
+# (from hash.py) then the source code has not changed and thus the zip file
+# should not have changed.
+if filename_old == filename_new:
+    if os.path.exists(filename_new):
+        # Update the file time so it doesn't get cleaned up,
+        # which would result in an unnecessary rebuild.
+        os.utime(filename_new, None)
+    else:
+        # If the file is missing, then it was probably generated on another
+        # machine, or it was created a long time ago and cleaned up. This is
+        # expected behaviour. However if Terraform needs to upload the file
+        # (e.g. someone manually deleted the Lambda function via the AWS
+        # console) then it is possible that Terraform will try to upload
+        # the missing file. I don't know how to tell if Terraform is going
+        # to try to upload the file or not, so always ensure the file exists.
+        subprocess.check_output(build_command, shell=True)
+
+# Output the filename to Terraform.
+json.dump({
+    'filename': filename_new,
+}, sys.stdout, indent=2)
+sys.stdout.write('\n')

--- a/hash.py
+++ b/hash.py
@@ -39,7 +39,7 @@ def delete_old_archives():
     """
 
     now = datetime.datetime.now()
-    delete_older_than = now - datetime.timedelta(hours=6)
+    delete_older_than = now - datetime.timedelta(days=7)
 
     top = '.terraform'
     if os.path.isdir(top):

--- a/lambda.tf
+++ b/lambda.tf
@@ -16,11 +16,7 @@ resource "aws_lambda_function" "lambda_without_vpc" {
 
   # Use a generated filename to determine when the source code has changed.
 
-  filename = "${lookup(data.external.archive.result, "filename")}"
-
-  # Depend on the null_resource to build the file when required.
-
-  depends_on = ["null_resource.archive"]
+  filename = "${lookup(data.external.built.result, "filename")}"
 
   # The aws_lambda_function resource has a schema for the environment
   # variable, where the only acceptable values are:
@@ -55,7 +51,6 @@ resource "aws_lambda_function" "lambda_with_vpc" {
   runtime       = "${var.runtime}"
   timeout       = "${var.timeout}"
   tags          = "${var.tags}"
-  filename      = "${lookup(data.external.archive.result, "filename")}"
-  depends_on    = ["null_resource.archive"]
+  filename      = "${lookup(data.external.built.result, "filename")}"
   environment   = ["${slice( list(var.environment), 0, length(var.environment) == 0 ? 0 : 1 )}"]
 }


### PR DESCRIPTION
If a Lambda function is manually deleted outside of Terraform, or in other weird cases that we don't understand, Terraform might try to upload a zip file that doesn't exist on disk.

Zip files are now kept for 7 days and if they don't exist, but might need to be uploaded, then a new data source will rebuild them.

This can result in zip files being built by a data source, where the built output won't be visible anywhere. This should only happen when the lambda function source code hasn't changed and it won't be uploaded (so you don't really care about the build output) or in the edge cases where it is trying to upload a file and it doesn't exist (not ideal to lose the build output, but it is better than getting an error). Outside of those 2 cases, the zip will be built by the null_resource and the output will be visible as expected.

Resolves #1