### PR TITLE
 Add support for dead_letter_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ module "lambda" {
   attach_policy = true
   policy        = "${data.aws_iam_policy_document.lambda.json}"
 
+  // Add a dead letter queue.
+  attach_dead_letter_config = true
+  dead_letter_config {
+    target_arn = "${var.dead_letter_queue_arn}"
+  }
+
   // Add environment variables.
   environment {
     variables {
@@ -62,8 +68,10 @@ function name unique per region, for example by setting
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| attach_dead_letter_config | Set this to true if using the dead_letter_config variable | string | `false` | no |
 | attach_policy | Set this to true if using the policy variable | string | `false` | no |
 | attach_vpc_config | Set this to true if using the vpc_config variable | string | `false` | no |
+| dead_letter_config | Dead letter configuration for the Lambda function | map | `<map>` | no |
 | description | Description of what your Lambda function does | string | `Managed by Terraform` | no |
 | environment | Environment configuration for the Lambda function | map | `<map>` | no |
 | function_name | A unique name for your Lambda function (and related IAM resources) | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ function name unique per region, for example by setting
 | attach_policy | Set this to true if using the policy variable | string | `false` | no |
 | attach_vpc_config | Set this to true if using the vpc_config variable | string | `false` | no |
 | description | Description of what your Lambda function does | string | `Managed by Terraform` | no |
-| environment | Environment configuration for the Lambda function | string | `<map>` | no |
+| environment | Environment configuration for the Lambda function | map | `<map>` | no |
 | function_name | A unique name for your Lambda function (and related IAM resources) | string | - | yes |
 | handler | The function entrypoint in your code | string | - | yes |
 | policy | An addional policy to attach to the Lambda function | string | `` | no |
 | runtime | The runtime environment for the Lambda function | string | - | yes |
-| source_path | The source file or directory containing your Lambda source code | string | `` | no |
-| tags | A mapping of tags | string | `<map>` | no |
+| source_path | The source file or directory containing your Lambda source code | string | - | yes |
+| tags | A mapping of tags | map | `<map>` | no |
 | timeout | The amount of time your Lambda function had to run in seconds | string | `10` | no |
-| vpc_config | VPC configuration for the Lambda function | string | `<map>` | no |
+| vpc_config | VPC configuration for the Lambda function | map | `<map>` | no |
 
 ## Outputs
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
 output "function_arn" {
   description = "The ARN of the Lambda function"
-  value       = "${element(concat(aws_lambda_function.lambda_with_vpc.*.arn, aws_lambda_function.lambda_without_vpc.*.arn), 0)}"
+  value       = "${lookup(element(concat(aws_lambda_function.lambda.*, aws_lambda_function.lambda_with_dl.*, aws_lambda_function.lambda_with_vpc.*, aws_lambda_function.lambda_with_dl_and_vpc.*), 0), "arn")}"
 }
 
 output "function_name" {
   description = "The name of the Lambda function"
-  value       = "${element(concat(aws_lambda_function.lambda_with_vpc.*.function_name, aws_lambda_function.lambda_without_vpc.*.function_name), 0)}"
+  value       = "${lookup(element(concat(aws_lambda_function.lambda.*, aws_lambda_function.lambda_with_dl.*, aws_lambda_function.lambda_with_vpc.*, aws_lambda_function.lambda_with_dl_and_vpc.*), 0), "function_name")}"
 }
 
 output "role_arn" {

--- a/tests/dead-letter-queue/lambda.py
+++ b/tests/dead-letter-queue/lambda.py
@@ -1,0 +1,5 @@
+def lambda_handler(event, context):
+    if event['pass']:
+        return True
+    else:
+        raise Exception('oh no')

--- a/tests/dead-letter-queue/main.tf
+++ b/tests/dead-letter-queue/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "random_id" "name" {
+  byte_length = 6
+  prefix      = "terraform-aws-lambda-dlq-"
+}
+
+resource "aws_sqs_queue" "dlq" {
+  name = "${random_id.name.hex}"
+}
+
+module "lambda" {
+  source = "../../"
+
+  function_name = "${random_id.name.hex}"
+  description   = "Test dead letter queue in terraform-aws-lambda"
+  handler       = "lambda.lambda_handler"
+  runtime       = "python3.6"
+  timeout       = 30
+
+  source_path = "${path.module}/lambda.py"
+
+  attach_dead_letter_config = true
+
+  dead_letter_config {
+    target_arn = "${aws_sqs_queue.dlq.arn}"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,18 @@ variable "environment" {
   default     = {}
 }
 
+variable "dead_letter_config" {
+  description = "Dead letter configuration for the Lambda function"
+  type        = "map"
+  default     = {}
+}
+
+variable "attach_dead_letter_config" {
+  description = "Set this to true if using the dead_letter_config variable"
+  type        = "string"
+  default     = false
+}
+
 variable "vpc_config" {
   description = "VPC configuration for the Lambda function"
   type        = "map"

--- a/variables.tf
+++ b/variables.tf
@@ -15,45 +15,53 @@ variable "runtime" {
 
 variable "timeout" {
   description = "The amount of time your Lambda function had to run in seconds"
+  type        = "string"
   default     = 10
 }
 
 variable "source_path" {
   description = "The source file or directory containing your Lambda source code"
-  default     = ""
+  type        = "string"
 }
 
 variable "description" {
   description = "Description of what your Lambda function does"
+  type        = "string"
   default     = "Managed by Terraform"
 }
 
 variable "environment" {
   description = "Environment configuration for the Lambda function"
+  type        = "map"
   default     = {}
 }
 
 variable "vpc_config" {
   description = "VPC configuration for the Lambda function"
+  type        = "map"
   default     = {}
 }
 
 variable "attach_vpc_config" {
   description = "Set this to true if using the vpc_config variable"
+  type        = "string"
   default     = false
 }
 
 variable "tags" {
   description = "A mapping of tags"
+  type        = "map"
   default     = {}
 }
 
 variable "policy" {
   description = "An addional policy to attach to the Lambda function"
+  type        = "string"
   default     = ""
 }
 
 variable "attach_policy" {
   description = "Set this to true if using the policy variable"
+  type        = "string"
   default     = false
 }


### PR DESCRIPTION
This is the same deal as `vpc_config` - Terraform doesn't cope with optional lists of maps with computed values, so now there is more copy/paste.