### PR TITLE
Remove deprecated aws_region argument

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -1,5 +1,3 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}


### PR DESCRIPTION
This change addresses this warning message:

[DEPRECATED] Defaults to current provider region if no other filtering is enabled