### PR TITLE
Migrate to python3 only, modern distributions ship with it by default

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Builds a zip file from the source_dir or source_file.
 # Installs dependencies with pip automatically.
 #
-
-from __future__ import print_function
 
 import base64
 import json
@@ -101,9 +99,8 @@ def create_zip_file(source_dir, target_file):
     cd(source_dir)
     run('zip', '-r', target_file, '.')
 
-
-# Parse the data from hash.py
-query = json.loads(base64.b64decode(sys.argv[1]))
+json_payload = base64.b64decode(sys.argv[1])
+query = json.loads(json_payload)
 filename = query['filename']
 runtime = query['runtime']
 source_path = query['source_path']

--- a/built.py
+++ b/built.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python2
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import json
 import os

--- a/hash.py
+++ b/hash.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Generates a content hash of the source_path, which is used to determine if
 # the Lambda code has changed, ignoring file modification and access times.
 #
 # Outputs a filename and a command to run if the archive needs to be built.
 #
-
-from __future__ import print_function
 
 import base64
 import datetime
@@ -114,6 +112,7 @@ def update_hash(hash_obj, file_root, file_path):
             hash_obj.update(data)
 
 
+
 current_dir = os.path.dirname(__file__)
 
 # Parse the query.
@@ -146,15 +145,17 @@ filename = '.terraform/{prefix}{content_hash}.zip'.format(
 )
 
 # Determine the command to run if Terraform wants to build a new archive.
-build_command = "'{build_script}' '{build_data}'".format(
+build_command = "{build_script} {build_data}".format(
     build_script=os.path.join(current_dir, 'build.py'),
-    build_data=base64.b64encode(
+    build_data=bytes.decode(base64.b64encode(str.encode(
         json.dumps({
             'filename': filename,
             'source_path': source_path,
             'runtime': runtime,
-        }).encode()
-    ),
+            })
+         )
+      ),
+   )
 )
 
 # Delete previous archives.


### PR DESCRIPTION
Hello @claranet,

Thanks for your terraform module, our team is very grateful for your effort since it helped us deploy our lambdas in production 👍 

We successfully migrated your module to python3 and tested it in [our infrastructure](https://github.com/umccr/infrastructure), it worked flawlessly after applying the changes.

I have also seen issue https://github.com/claranet/terraform-aws-lambda/issues/5, but I disagree with its assessment. At the time of writing this, most modern (cloud) distributions ship with python3 by default, so having python2 in the way just complicates things.

Please join the push to move towards python3!: 

https://python3statement.org/

/cc @vladsaveliev @reisingerf