### PR TITLE
Adds Windows support

### DIFF
--- a/build.py
+++ b/build.py
@@ -96,8 +96,7 @@ def create_zip_file(source_dir, target_file):
     target_dir = os.path.dirname(target_file)
     if not os.path.exists(target_dir):
         os.makedirs(target_dir)
-    cd(source_dir)
-    run('zip', '-r', target_file, '.')
+    shutil.make_archive(target_file, format='zip', root_dir=source_dir)
 
 json_payload = bytes.decode(base64.b64decode(sys.argv[1]))
 query = json.loads(json_payload)
@@ -143,5 +142,5 @@ with tempdir() as temp_dir:
 
     # Zip up the temporary directory and write it to the target filename.
     # This will be used by the Lambda function as the source code package.
-    create_zip_file(temp_dir, absolute_filename)
+    create_zip_file(temp_dir, os.path.splitext(absolute_filename)[0])
     print('Created {}'.format(filename))

--- a/build.py
+++ b/build.py
@@ -15,15 +15,20 @@ import tempfile
 from contextlib import contextmanager
 
 
+@contextmanager
 def cd(path):
     """
     Changes the working directory.
 
     """
 
-    if os.getcwd() != path:
-        print('cd', path)
+    cwd = os.getcwd()
+    print('cd', path)
+    try:
         os.chdir(path)
+        yield
+    finally:
+        os.chdir(cwd)
 
 
 def format_command(command):
@@ -119,26 +124,26 @@ with tempdir() as temp_dir:
         source_files = [os.path.basename(source_path)]
 
     # Copy them into the temporary directory.
-    cd(source_dir)
-    for file_name in source_files:
-        target_path = os.path.join(temp_dir, file_name)
-        target_dir = os.path.dirname(target_path)
-        if not os.path.exists(target_dir):
-            print('mkdir -p {}'.format(target_dir))
-            os.makedirs(target_dir)
-        print('cp {} {}'.format(file_name, target_path))
-        shutil.copyfile(file_name, target_path)
+    with cd(source_dir):
+        for file_name in source_files:
+            target_path = os.path.join(temp_dir, file_name)
+            target_dir = os.path.dirname(target_path)
+            if not os.path.exists(target_dir):
+                print('mkdir -p {}'.format(target_dir))
+                os.makedirs(target_dir)
+            print('cp {} {}'.format(file_name, target_path))
+            shutil.copyfile(file_name, target_path)
 
     # Install dependencies into the temporary directory.
     if runtime.startswith('python'):
         requirements = os.path.join(temp_dir, 'requirements.txt')
         if os.path.exists(requirements):
-            cd(temp_dir)
-            if runtime.startswith('python3'):
-                pip_command = 'pip3'
-            else:
-                pip_command = 'pip2'
-            run(pip_command, 'install', '-r', 'requirements.txt', '-t', '.')
+            with cd(temp_dir):
+                if runtime.startswith('python3'):
+                    pip_command = 'pip3'
+                else:
+                    pip_command = 'pip2'
+                run(pip_command, 'install', '-r', 'requirements.txt', '-t', '.')
 
     # Zip up the temporary directory and write it to the target filename.
     # This will be used by the Lambda function as the source code package.

--- a/tests/python-cmd/lambda.py
+++ b/tests/python-cmd/lambda.py
@@ -1,0 +1,2 @@
+def lambda_handler(event, context):
+    return 'test passed'

--- a/tests/python-cmd/main.tf
+++ b/tests/python-cmd/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "lambda" {
+  source = "../../"
+
+  function_name                  = "terraform-aws-lambda-test-python-cmd"
+  description                    = "Test python_cmd in terraform-aws-lambda"
+  handler                        = "lambda.lambda_handler"
+  memory_size                    = 256
+  reserved_concurrent_executions = 3
+  runtime                        = "python3.6"
+  timeout                        = 30
+
+  python_cmd = ["python"]
+
+  source_path = "${path.module}/lambda.py"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -89,3 +89,9 @@ variable "attach_policy" {
   type        = "string"
   default     = false
 }
+
+variable "python_cmd" {
+  description = "Entry point of the python binary for external python scripts"
+  type        = "list"
+  default     = []
+}


### PR DESCRIPTION
There were three problems preventing execution on Windows:

1. Reliance exclusively on the shebang and the execute bit to execute python scripts
2. Subprocess call to `zip` to create the zip file
3. The `cd` function stayed in `temp_dir`, preventing removal

To address the first problem, a new optional variable was added `python_cmd`. A user on Windows can set this to the path to python.exe (or if the desired interpreter is first in the PATH, then just `python` works). The variable was implemented as a list to support passing python options, if the user needs them.

The second problem was resolved by using the `shutil.make_archive` function from the builtin library. This works across platforms.

The third problem was resolved by implementing `cd` as a context manager, to ensure we leave the directory before removing it.

Fixes #19 
