### PR TITLE
Retrieves the current partition to construct ARNs for IAM roles

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -1,3 +1,5 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_region" "current" {}

--- a/iam.tf
+++ b/iam.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "logs" {
     ]
 
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*",
+      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*",
     ]
   }
 
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "logs" {
     ]
 
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.function_name}:*",
+      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.function_name}:*",
     ]
   }
 }


### PR DESCRIPTION
The partition for GovCloud is `aws-us-gov`. When the value is hard-coded to `aws`, the IAM role is not created in GovCloud. Issue also exists with the China partition. This patch allows the IAM role to be created properly in all partitions.