### PR TITLE
Allow use of existing policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ module "lambda" {
 
   // Attach a policy.
   attach_policy = true
-  policy        = "${data.aws_iam_policy_document.lambda.json}"
+  policy_arn    = "${data.aws_iam_policy.lambda.arn}"
 
   // Add a dead letter queue.
   attach_dead_letter_config = true
@@ -77,7 +77,7 @@ function name unique per region, for example by setting
 | function_name | A unique name for your Lambda function (and related IAM resources) | string | - | yes |
 | handler | The function entrypoint in your code | string | - | yes |
 | memory_size | Amount of memory in MB your Lambda function can use at runtime | string | `128` | no |
-| policy | An addional policy to attach to the Lambda function | string | `` | no |
+| policy_arn | An addional policy (ARN) to attach to the Lambda function | string | `` | no |
 | reserved_concurrent_executions | The amount of reserved concurrent executions for this Lambda function | string | `0` | no |
 | runtime | The runtime environment for the Lambda function | string | - | yes |
 | source_path | The source file or directory containing your Lambda source code | string | - | yes |

--- a/iam.tf
+++ b/iam.tf
@@ -126,17 +126,8 @@ resource "aws_iam_policy_attachment" "network" {
 
 # Attach an additional policy if provided.
 
-resource "aws_iam_policy" "additional" {
-  count = "${var.attach_policy ? 1 : 0}"
-
-  name   = "${var.function_name}"
-  policy = "${var.policy}"
-}
-
-resource "aws_iam_policy_attachment" "additional" {
-  count = "${var.attach_policy ? 1 : 0}"
-
-  name       = "${var.function_name}"
-  roles      = ["${aws_iam_role.lambda.name}"]
-  policy_arn = "${aws_iam_policy.additional.arn}"
+resource "aws_iam_role_policy_attachment" "additional" {
+  count      = "${var.attach_policy ? 1 : 0}"
+  role       = "${aws_iam_role.lambda.name}"
+  policy_arn = "${var.policy_arn}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -78,14 +78,14 @@ variable "tags" {
   default     = {}
 }
 
-variable "policy" {
-  description = "An addional policy to attach to the Lambda function"
+variable "policy_arn" {
+  description = "An addional policy (ARN) to attach to the Lambda function"
   type        = "string"
   default     = ""
 }
 
 variable "attach_policy" {
-  description = "Set this to true if using the policy variable"
+  description = "Set this to true if using the policy_arn variable"
   type        = "string"
   default     = false
 }


### PR DESCRIPTION
Rather than creating a new policy form a referenced policy document, allow the use of an existing policy by specifying it's ARN. 
This not only allows the re-use of an existing policy, but also the control over other `aws_iam_policy` arguments like `path` and `description`.