### PR TITLE
optionally disable cloudwatch logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ function name unique per region, for example by setting
 | attach_dead_letter_config | Set this to true if using the dead_letter_config variable | string | `false` | no |
 | attach_policy | Set this to true if using the policy variable | string | `false` | no |
 | attach_vpc_config | Set this to true if using the vpc_config variable | string | `false` | no |
+| enable_cloudwatch_logs | Set this to false to disable logging your Lambda output to Cloudwatch Logs | string | `true` | no |
 | dead_letter_config | Dead letter configuration for the Lambda function | map | `<map>` | no |
 | description | Description of what your Lambda function does | string | `Managed by Terraform` | no |
 | environment | Environment configuration for the Lambda function | map | `<map>` | no |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ function name unique per region, for example by setting
 | attach_dead_letter_config | Set this to true if using the dead_letter_config variable | string | `false` | no |
 | attach_policy | Set this to true if using the policy variable | string | `false` | no |
 | attach_vpc_config | Set this to true if using the vpc_config variable | string | `false` | no |
-| enable_cloudwatch_logs | Set this to false to disable logging your Lambda output to Cloudwatch Logs | string | `true` | no |
+| enable_cloudwatch_logs | Set this to false to disable logging your Lambda output to CloudWatch Logs | string | `true` | no |
 | dead_letter_config | Dead letter configuration for the Lambda function | map | `<map>` | no |
 | description | Description of what your Lambda function does | string | `Managed by Terraform` | no |
 | environment | Environment configuration for the Lambda function | map | `<map>` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -20,6 +20,8 @@ resource "aws_iam_role" "lambda" {
 # Attach a policy for logs.
 
 data "aws_iam_policy_document" "logs" {
+  count = "${var.enable_cloudwatch_logs ? 1 : 0}"
+
   statement {
     effect = "Allow"
 
@@ -47,11 +49,15 @@ data "aws_iam_policy_document" "logs" {
 }
 
 resource "aws_iam_policy" "logs" {
+  count = "${var.enable_cloudwatch_logs ? 1 : 0}"
+
   name   = "${var.function_name}-logs"
   policy = "${data.aws_iam_policy_document.logs.json}"
 }
 
 resource "aws_iam_policy_attachment" "logs" {
+  count = "${var.enable_cloudwatch_logs ? 1 : 0}"
+
   name       = "${var.function_name}-logs"
   roles      = ["${aws_iam_role.lambda.name}"]
   policy_arn = "${aws_iam_policy.logs.arn}"

--- a/variables.tf
+++ b/variables.tf
@@ -89,3 +89,9 @@ variable "attach_policy" {
   type        = "string"
   default     = false
 }
+
+variable "enable_cloudwatch_logs" {
+  description = "Set this to false to disable logging your Lambda output to Cloudwatch Logs"
+  type        = "string"
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -91,7 +91,7 @@ variable "attach_policy" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Set this to false to disable logging your Lambda output to Cloudwatch Logs"
+  description = "Set this to false to disable logging your Lambda output to CloudWatch Logs"
   type        = "string"
   default     = true
 }


### PR DESCRIPTION
Adds an `enable_cloudwatch_logs` variable.
> Set this to false to disable logging your Lambda output to Cloudwatch Logs