### PR TITLE
Support for scheduled lambda runs through Cloudwatch Events rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ module "lambda" {
     subnet_ids         = ["${aws_subnet.test.id}"]
     security_group_ids = ["${aws_security_group.test.id}"]
   }
+
+  // Trigger from a Cloudwatch Events rule.
+  attach_cloudwatch_rule_config = true
+  cloudwatch_rule_config {
+    name                = "scheduled-run"
+    enabled             = true // set this to false if you want to have the trigger declared but disabled
+    description         = "Run my lambda every day at 8pm"
+    schedule_expression = "cron(0 20 * * ? *)"
+  }
 }
 ```
 
@@ -68,11 +77,13 @@ function name unique per region, for example by setting
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| attach\_cloudwatch\_rule\_config | Set this to true if using the cloudwatch_rule_config variable | string | `false` | no |
 | attach\_dead\_letter\_config | Set this to true if using the dead_letter_config variable | string | `"false"` | no |
 | attach\_policy | Set this to true if using the policy variable | string | `"false"` | no |
 | attach\_vpc\_config | Set this to true if using the vpc_config variable | string | `"false"` | no |
 | build\_command | The command that creates the Lambda package zip file | string | `"python build.py '$filename' '$runtime' '$source'"` | no |
 | build\_paths | The files or directories used by the build command, to trigger new Lambda package builds whenever build scripts change | list | `<list>` | no |
+| cloudwatch\_rule\_config | Cloudwatch Rule for the Lambda function | map | `<map>` | no |
 | dead\_letter\_config | Dead letter configuration for the Lambda function | map | `<map>` | no |
 | description | Description of what your Lambda function does | string | `"Managed by Terraform"` | no |
 | enable\_cloudwatch\_logs | Set this to false to disable logging your Lambda output to CloudWatch Logs | string | `"true"` | no |
@@ -92,6 +103,7 @@ function name unique per region, for example by setting
 
 | Name | Description |
 |------|-------------|
+| cloudwatch\_rule\_arn | The ARN of the Cloudwatch rule |
 | function\_arn | The ARN of the Lambda function |
 | function\_name | The name of the Lambda function |
 | role\_arn | The ARN of the IAM role created for the Lambda function |

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,21 @@
+resource "aws_lambda_permission" "cloudwatch_trigger" {
+    count         = "${var.attach_cloudwatch_rule_config ? 1 : 0}"
+    statement_id  = "AllowExecutionFromCloudWatch"
+    action        = "${lookup(var.cloudwatch_rule_config, "enabled", true) ? "lambda:InvokeFunction" : "lambda:DisableInvokeFunction"}"
+    function_name = "${element(concat(aws_lambda_function.lambda.*.function_name, aws_lambda_function.lambda_with_dl.*.function_name, aws_lambda_function.lambda_with_vpc.*.function_name, aws_lambda_function.lambda_with_dl_and_vpc.*.function_name), 0)}"
+    principal     = "events.amazonaws.com"
+    source_arn    = "${aws_cloudwatch_event_rule.rule.arn}"
+}
+resource "aws_cloudwatch_event_rule" "rule" {
+    count               = "${var.attach_cloudwatch_rule_config ? 1 : 0}"
+    name                = "${var.cloudwatch_rule_config["name"]}"
+    description         = "${var.cloudwatch_rule_config["description"]}"
+    schedule_expression = "${var.cloudwatch_rule_config["schedule_expression"]}"
+}
+
+resource "aws_cloudwatch_event_target" "target" {
+    count     = "${var.attach_cloudwatch_rule_config ? 1 : 0}"
+    target_id = "${element(concat(aws_lambda_function.lambda.*.function_name, aws_lambda_function.lambda_with_dl.*.function_name, aws_lambda_function.lambda_with_vpc.*.function_name, aws_lambda_function.lambda_with_dl_and_vpc.*.function_name), 0)}"
+    rule      = "${aws_cloudwatch_event_rule.rule.name}"
+    arn       = "${element(concat(aws_lambda_function.lambda.*.arn, aws_lambda_function.lambda_with_dl.*.arn, aws_lambda_function.lambda_with_vpc.*.arn, aws_lambda_function.lambda_with_dl_and_vpc.*.arn), 0)}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output "role_name" {
   description = "The name of the IAM role created for the Lambda function"
   value       = "${aws_iam_role.lambda.name}"
 }
+
+output "cloudwatch_rule_arn" {
+  description = "The ARN of the Cloudwatch rule"
+  value       = "${element(concat(aws_cloudwatch_event_rule.rule.*.arn), 0)}"
+}

--- a/tests/cloudwatch-event-trigger/lambda.py
+++ b/tests/cloudwatch-event-trigger/lambda.py
@@ -1,0 +1,2 @@
+def lambda_handler(event, context):
+    return 'test passed'

--- a/tests/cloudwatch-event-trigger/main.tf
+++ b/tests/cloudwatch-event-trigger/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "random_id" "name" {
+  byte_length = 6
+  prefix      = "terraform-aws-lambda-scheduled-"
+}
+
+module "lambda" {
+  source = "../../"
+
+  function_name = "${random_id.name.hex}"
+  description   = "Test cloudwatch rule trigger in terraform-aws-lambda"
+  handler       = "lambda.lambda_handler"
+  runtime       = "python3.6"
+  timeout       = 30
+
+  source_path = "${path.module}/lambda.py"
+
+  attach_cloudwatch_rule_config = true
+
+  cloudwatch_rule_config {
+    name = "scheduled-run"
+    # enabled = false
+    description = "Test scheduled lambda run"
+    schedule_expression = "cron(0 20 * * ? *)"
+  }
+}
+
+output "cloudwatchrule_arn" {
+  value = "${module.lambda.cloudwatch_rule_arn}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,18 @@ variable "attach_vpc_config" {
   default     = false
 }
 
+variable "cloudwatch_rule_config" {
+  description = "Cloudwatch Rule for the Lambda function"
+  type        = "map"
+  default     = {}
+}
+
+variable "attach_cloudwatch_rule_config" {
+  description = "Set this to true if using the cloudwatch_rule_config variable"
+  type        = "string"
+  default     = false
+}
+
 variable "tags" {
   description = "A mapping of tags"
   type        = "map"


### PR DESCRIPTION
this patch allow provisioning cloudwatch event rules from within the module. for now only scheduled execution is supported.