### PR TITLE
FIX: Preserve permissions when building archive

### DIFF
--- a/build.py
+++ b/build.py
@@ -132,6 +132,7 @@ with tempdir() as temp_dir:
                 os.makedirs(target_dir)
             print('cp {} {}'.format(file_name, target_path))
             shutil.copyfile(file_name, target_path)
+            shutil.copymode(file_name, target_path)
 
     # Install dependencies into the temporary directory.
     if runtime.startswith('python'):


### PR DESCRIPTION
Permissions are not copied when copying the source files into the
temporary directory in preparation for building the archive. This
can make previously executable binaries no longer work in the lambda
environment.

Copy the permission bits of the original files when copying the files.