### PR TITLE
Update default value of reserved_concurrent_executions to -1

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ function name unique per region, for example by setting
 | memory\_size | Amount of memory in MB your Lambda function can use at runtime | string | `"128"` | no |
 | policy | An addional policy to attach to the Lambda function | string | `""` | no |
 | publish | Whether to publish creation/change as new Lambda Function Version | string | `"false"` | no |
-| reserved\_concurrent\_executions | The amount of reserved concurrent executions for this Lambda function | string | `"0"` | no |
+| reserved\_concurrent\_executions | The amount of reserved concurrent executions for this Lambda function | string | `"-1"` | no |
 | runtime | The runtime environment for the Lambda function | string | n/a | yes |
 | source\_path | The source file or directory containing your Lambda source code | string | n/a | yes |
 | tags | A mapping of tags | map | `<map>` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "memory_size" {
 variable "reserved_concurrent_executions" {
   description = "The amount of reserved concurrent executions for this Lambda function"
   type        = "string"
-  default     = 0
+  default     = -1
 }
 
 variable "runtime" {


### PR DESCRIPTION
As https://github.com/terraform-providers/terraform-provider-aws/pull/3806 has been merged into the Terraform AWS Provider 2.0, the current default value of this module will effectively mean no Lambda invocations will be handled. By setting the default value to -1 instead of 0, we return to the original unrestricted value. 