### PR TITLE
Applies tags to iam role resource

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -15,6 +15,7 @@ data "aws_iam_policy_document" "assume_role" {
 resource "aws_iam_role" "lambda" {
   name               = "${var.function_name}"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  tags               = "${var.tags}"
 }
 
 # Attach a policy for logs.


### PR DESCRIPTION
We have a default set of tags we apply to every resource, and would like to be able to pass the tags through this module to the IAM role created by the module (in addition to the lambda function).

Could alternatively use a separate var for the IAM role, or use `tags` on both and introduce new per-resource tag vars. As implemented currently, it is sufficient for _us_, happy to revise as needed.