### PR TITLE
Ensures quoted arguments are handled similarly across platforms

### DIFF
--- a/build.py
+++ b/build.py
@@ -2,6 +2,7 @@
 # Installs dependencies with pip automatically.
 
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -104,9 +105,17 @@ def create_zip_file(source_dir, target_file):
     )
 
 
-filename = sys.argv[1]
-runtime = sys.argv[2]
-source_path = sys.argv[3]
+def dequote(value):
+    """
+    Handles quotes around values in a shell-compatible fashion.
+
+    """
+    return ' '.join(shlex.split(value))
+
+
+filename = dequote(sys.argv[1])
+runtime = dequote(sys.argv[2])
+source_path = dequote(sys.argv[3])
 
 absolute_filename = os.path.abspath(filename)
 


### PR DESCRIPTION
With this patch, the inputs in build.py resolve the same on both linux and windows.

```
null_resource.archive (local-exec): cd C:\...
```

```
null_resource.archive (local-exec): cd /home/...
```

Fixes #43