### PR TITLE
Add AWS Provider Version Constraint

### DIFF
--- a/meta.tf
+++ b/meta.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  version = ">= 2.0.0"
+}


### PR DESCRIPTION
AWS Provider modifies the way Lambda Concurrency is handled so that:

  -1 == unreserved concurrency
   0 == zero concurrency (do not run)
  >1 == reserved concurrency limits

previous provider versions had used 0 to indicate unreserved
concurrency

This change adds the AWS provider version constraing `>= 2.0.0` to
ensure the provider behaves as expected for the module