### PR TITLE
feature: add built filename to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,9 @@ output "role_name" {
   description = "The name of the IAM role created for the Lambda function"
   value       = "${aws_iam_role.lambda.name}"
 }
+
+output "build_result_filename" {
+  description = "Full path to the source code package with requirements installed"
+  value       = "${lookup(data.external.built.result, "filename")}"
+}
+


### PR DESCRIPTION
Sometimes I just need ZIP file too. For example when having several lambdas with different handlers from one source. Or when providing same sources to Glue "py-extra-files"