### PR TITLE
hash.py: return from delete_old_archives if builds dir missing

### DIFF
--- a/hash.py
+++ b/hash.py
@@ -27,6 +27,9 @@ def delete_old_archives():
 
     """
 
+    if not os.path.exists('builds'):
+        return
+    
     now = datetime.datetime.now()
     delete_older_than = now - datetime.timedelta(days=7)
 


### PR DESCRIPTION
Guard against exceptions due to missing the `builds` directory in ephemeral environments (e.g. `terraform-cloud`)