### PR TITLE
New feature - Additional trust relashionships

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ module "lambda" {
   // Specify a file or directory for the source code.
   source_path = "${path.module}/lambda.py"
 
-  // Add additional assume roles (trust relationships).
-  assume_roles = ["events.amazonaws.com", "s3.amazonaws.com"]
+  // Add additional trusted entities for assuming roles (trust relationships).
+  trusted_entities = ["events.amazonaws.com", "s3.amazonaws.com"]
 
   // Attach a policy.
   policy = {
@@ -78,7 +78,7 @@ Inputs for this module are the same as the [aws_lambda_function](https://www.ter
 | cloudwatch\_logs | Set this to false to disable logging your Lambda output to CloudWatch Logs | `bool` | `true` | no |
 | lambda\_at\_edge | Set this to true if using Lambda@Edge, to enable publishing, limit the timeout, and allow edgelambda.amazonaws.com to invoke the function | `bool` | `false` | no |
 | policy | An additional policy to attach to the Lambda function role | `object({json=string})` | | no |
-| assume\_roles | Additional assume roles for the Lambda function. The lambda.amazonaws.com (and edgelambda.amazonaws.com if lambda\_at\_edge is true) is always set  | `list(string)` | | no |
+| trusted\_entities | Additional trusted entities for the Lambda function. The lambda.amazonaws.com (and edgelambda.amazonaws.com if lambda\_at\_edge is true) is always set  | `list(string)` | | no |
 
 The following arguments from the [aws_lambda_function](https://www.terraform.io/docs/providers/aws/r/lambda_function.html) resource are not supported:
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ module "lambda" {
   // Specify a file or directory for the source code.
   source_path = "${path.module}/lambda.py"
 
+  // Add additional assume roles (trust relationships).
+  assume_roles = ["events.amazonaws.com", "s3.amazonaws.com"]
+
   // Attach a policy.
   policy = {
     json = data.aws_iam_policy_document.lambda.json
@@ -75,6 +78,7 @@ Inputs for this module are the same as the [aws_lambda_function](https://www.ter
 | cloudwatch\_logs | Set this to false to disable logging your Lambda output to CloudWatch Logs | `bool` | `true` | no |
 | lambda\_at\_edge | Set this to true if using Lambda@Edge, to enable publishing, limit the timeout, and allow edgelambda.amazonaws.com to invoke the function | `bool` | `false` | no |
 | policy | An additional policy to attach to the Lambda function role | `object({json=string})` | | no |
+| assume\_roles | Additional assume roles for the Lambda function. The lambda.amazonaws.com (and edgelambda.amazonaws.com if lambda\_at\_edge is true) is always set  | `list(string)` | | no |
 
 The following arguments from the [aws_lambda_function](https://www.terraform.io/docs/providers/aws/r/lambda_function.html) resource are not supported:
 

--- a/iam.tf
+++ b/iam.tf
@@ -7,20 +7,20 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = slice(list("lambda.amazonaws.com", "edgelambda.amazonaws.com"), 0, var.lambda_at_edge ? 2 : 1)
+      identifiers = concat(slice(list("lambda.amazonaws.com", "edgelambda.amazonaws.com"), 0, var.lambda_at_edge ? 2 : 1), var.assume_roles)
     }
   }
 
-  # Adding events role as trust relationship
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
+  # # Adding additional assumer roles for trust relationships
+  # statement {
+  #   effect  = "Allow"
+  #   actions = ["sts:AssumeRole"]
 
-    principals {
-      type        = "Service"
-      identifiers = var.assume_roles
-    }
-  }
+  #   principals {
+  #     type        = "Service"
+  #     identifiers = var.assume_roles
+  #   }
+  # }
 }
 
 resource "aws_iam_role" "lambda" {

--- a/iam.tf
+++ b/iam.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = concat(slice(list("lambda.amazonaws.com", "edgelambda.amazonaws.com"), 0, var.lambda_at_edge ? 2 : 1), var.assume_roles)
+      identifiers = concat(slice(list("lambda.amazonaws.com", "edgelambda.amazonaws.com"), 0, var.lambda_at_edge ? 2 : 1), var.trusted_entities)
     }
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -10,6 +10,17 @@ data "aws_iam_policy_document" "assume_role" {
       identifiers = slice(list("lambda.amazonaws.com", "edgelambda.amazonaws.com"), 0, var.lambda_at_edge ? 2 : 1)
     }
   }
+
+  # Adding events role as trust relationship
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
 }
 
 resource "aws_iam_role" "lambda" {

--- a/iam.tf
+++ b/iam.tf
@@ -10,17 +10,6 @@ data "aws_iam_policy_document" "assume_role" {
       identifiers = concat(slice(list("lambda.amazonaws.com", "edgelambda.amazonaws.com"), 0, var.lambda_at_edge ? 2 : 1), var.assume_roles)
     }
   }
-
-  # # Adding additional assumer roles for trust relationships
-  # statement {
-  #   effect  = "Allow"
-  #   actions = ["sts:AssumeRole"]
-
-  #   principals {
-  #     type        = "Service"
-  #     identifiers = var.assume_roles
-  #   }
-  # }
 }
 
 resource "aws_iam_role" "lambda" {

--- a/iam.tf
+++ b/iam.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["events.amazonaws.com"]
+      identifiers = var.assume_roles
     }
   }
 }

--- a/tests/assume-roles/lambda.py
+++ b/tests/assume-roles/lambda.py
@@ -1,0 +1,5 @@
+def lambda_handler(event, context):
+    if event['pass']:
+        return True
+    else:
+        raise Exception('oh no')

--- a/tests/assume-roles/main.tf
+++ b/tests/assume-roles/main.tf
@@ -1,0 +1,106 @@
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "random_id" "name" {
+  byte_length = 6
+  prefix      = "terraform-aws-lambda-policy-"
+}
+
+resource "aws_sqs_queue" "test" {
+  name = random_id.name.hex
+}
+
+data "aws_iam_policy_document" "computed" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sqs:SendMessage",
+    ]
+
+    resources = [
+      aws_sqs_queue.test.arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "known" {
+  statement {
+    effect = "Deny"
+
+    actions = [
+      "sqs:SendMessage",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+module "lambda_with_computed_policy_add_trust_relationships" {
+  source = "../../"
+
+  function_name = "${random_id.name.hex}-computed"
+  description   = "Test attaching policy with additional trust relationships in terraform-aws-lambda"
+  handler       = "lambda.lambda_handler"
+  runtime       = "python3.6"
+
+  source_path = "${path.module}/lambda.py"
+
+  assume_roles = ["events.amazonaws.com"]
+
+  policy = {
+    json = data.aws_iam_policy_document.computed.json
+  }
+}
+
+
+module "lambda_with_known_policy_add_trust_relationships" {
+  source = "../../"
+
+  function_name = "${random_id.name.hex}-known"
+  description   = "Test attaching policy with additional trust relationships in terraform-aws-lambda"
+  handler       = "lambda.lambda_handler"
+  runtime       = "python3.6"
+
+  source_path = "${path.module}/lambda.py"
+
+  assume_roles = ["events.amazonaws.com"]
+
+  policy = {
+    json = data.aws_iam_policy_document.known.json
+  }
+}
+
+
+module "lambda_without_policy_add_trust_relationships" {
+  source = "../../"
+
+  function_name = "${random_id.name.hex}-without"
+  description   = "Test attaching policy with additional trust relationships in terraform-aws-lambda"
+  handler       = "lambda.lambda_handler"
+  runtime       = "python3.6"
+
+  source_path = "${path.module}/lambda.py"
+
+  assume_roles = ["events.amazonaws.com"]
+}
+
+module "lambda_without_policy_without_added_trust_relationships" {
+  source = "../../"
+
+  function_name = "${random_id.name.hex}-without"
+  description   = "Test attaching policy with additional trust relationships in terraform-aws-lambda"
+  handler       = "lambda.lambda_handler"
+  runtime       = "python3.6"
+
+  source_path = "${path.module}/lambda.py"
+}

--- a/tests/assume-roles/main.tf
+++ b/tests/assume-roles/main.tf
@@ -55,7 +55,7 @@ module "lambda_with_computed_policy_add_trust_relationships" {
 
   source_path = "${path.module}/lambda.py"
 
-  assume_roles = ["events.amazonaws.com"]
+  trusted_entities = ["events.amazonaws.com"]
 
   policy = {
     json = data.aws_iam_policy_document.computed.json
@@ -73,7 +73,7 @@ module "lambda_with_known_policy_add_trust_relationships" {
 
   source_path = "${path.module}/lambda.py"
 
-  assume_roles = ["events.amazonaws.com"]
+  trusted_entities = ["events.amazonaws.com"]
 
   policy = {
     json = data.aws_iam_policy_document.known.json
@@ -91,7 +91,7 @@ module "lambda_without_policy_add_trust_relationships" {
 
   source_path = "${path.module}/lambda.py"
 
-  assume_roles = ["events.amazonaws.com"]
+  trusted_entities = ["events.amazonaws.com"]
 }
 
 module "lambda_without_policy_without_added_trust_relationships" {

--- a/variables.tf
+++ b/variables.tf
@@ -51,8 +51,8 @@ variable "policy" {
   default = null
 }
 
-variable "assume_roles" {
-  description = "Lambda function additional assume roles (trust relationship)"
+variable "trusted_entities" {
+  description = "Lambda function additional trusted entities for assuming roles (trust relationship)"
   type = list(string)
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,9 +52,9 @@ variable "policy" {
 }
 
 variable "assume_roles" {
-  description = "Lambda function assume roles (trust relationship)"
+  description = "Lambda function additional assume roles (trust relationship)"
   type = list(string)
-  default = null
+  default = []
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,12 @@ variable "policy" {
   default = null
 }
 
+variable "assume_roles" {
+  description = "Lambda function assume roles (trust relationship)"
+  type = list(string)
+  default = null
+}
+
 locals {
   publish = var.lambda_at_edge ? true : var.publish
   timeout = var.lambda_at_edge ? min(var.timeout, 5) : var.timeout


### PR DESCRIPTION
This branch features the possibility to add additional trust relationships to the Lambda role. These trust relationships are added to the lambda.amazonaws.com (and edgelambda.amazonaws.com if lambda_at_edge is true). Tests for the new feature are provided as well.