### PR TITLE
Zip file is created every time

### DIFF
--- a/built.py
+++ b/built.py
@@ -18,10 +18,10 @@ module_relpath = query['module_relpath']
 # (from hash.py) then the source code has not changed and thus the zip file
 # should not have changed.
 if filename_old == filename_new:
-    if os.path.exists(filename_new):
+    if os.path.exists(module_relpath + filename_new):
         # Update the file time so it doesn't get cleaned up,
         # which would result in an unnecessary rebuild.
-        os.utime(filename_new, None)
+        os.utime(module_relpath + filename_new, None)
     else:
         # If the file is missing, then it was probably generated on another
         # machine, or it was created a long time ago and cleaned up. This is


### PR DESCRIPTION
First of all, Congratulations for this module. I love it.

I have noticed the zip file is created every time when terraform apply runs ( With or Without source code changes)
This doesn't have an impact, because the trigger to replace the lambda is the filename.
In your built.py script, you have a code to update the time if the file doesn't change. But when you check if the path exists, the path is the relative path from the directory where I ran the terraform apply command, so the path don't exist and will build the file again, with the same name. If we put the module_realpath, the problem is solved.