### PR TITLE
kms_key_arn is declared but unused

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -10,6 +10,7 @@ resource "aws_lambda_function" "lambda" {
   layers                         = var.layers
   timeout                        = local.timeout
   publish                        = local.publish
+  kms_key_arn                    = var.kms_key_arn
   tags                           = var.tags
 
   # Use a generated filename to determine when the source code has changed.


### PR DESCRIPTION
The `kms_key_arn` input is declared in the `variables.tf` file but unused in the `lambda` resource. This PR would fix that allowing users to set a custom KMS key to encrypt the environment variables their Lambda function use.