### PR TITLE
list() is deprecated since 0.12 and removed in 0.15

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = concat(slice(list("lambda.amazonaws.com", "edgelambda.amazonaws.com"), 0, var.lambda_at_edge ? 2 : 1), var.trusted_entities)
+      identifiers = concat(slice(["lambda.amazonaws.com", "edgelambda.amazonaws.com"], 0, var.lambda_at_edge ? 2 : 1), var.trusted_entities)
     }
   }
 }
@@ -23,7 +23,7 @@ resource "aws_iam_role" "lambda" {
 locals {
   lambda_log_group_arn      = "arn:${data.aws_partition.current.partition}:logs:*:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.function_name}"
   lambda_edge_log_group_arn = "arn:${data.aws_partition.current.partition}:logs:*:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/us-east-1.${var.function_name}"
-  log_group_arns            = slice(list(local.lambda_log_group_arn, local.lambda_edge_log_group_arn), 0, var.lambda_at_edge ? 2 : 1)
+  log_group_arns            = slice([local.lambda_log_group_arn, local.lambda_edge_log_group_arn], 0, var.lambda_at_edge ? 2 : 1)
 }
 
 data "aws_iam_policy_document" "logs" {


### PR DESCRIPTION
Without this change, using this module with terraform 0.15-rc2 fails with the following error:

```
╷
│ Error: Error in function call
│
│   on .terraform/modules/mymodule.lambda-1/iam.tf line 10, in data "aws_iam_policy_document" "assume_role":
│   10:       identifiers = concat(slice(list("lambda.amazonaws.com", "edgelambda.amazonaws.com"), 0, var.lambda_at_edge ? 2 : 1), var.trusted_entities)
│
│ Call to function "list" failed: the "list" function was deprecated in Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to write a literal list.
╵
╷
│ Error: Error in function call
│
│   on .terraform/modules/mymodule.lambda-1/iam.tf line 26, in locals:
│   26:   log_group_arns            = slice(list(local.lambda_log_group_arn, local.lambda_edge_log_group_arn), 0, var.lambda_at_edge ? 2 : 1)
│     ├────────────────
│     │ local.lambda_edge_log_group_arn is a string, known only after apply
│     │ local.lambda_log_group_arn is a string, known only after apply
│
│ Call to function "list" failed: the "list" function was deprecated in Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to write a literal list.
╵
```
