### PR TITLE
Ignore __pycache__

### DIFF
--- a/build.py
+++ b/build.py
@@ -51,6 +51,8 @@ def list_files(top_path):
     results = []
 
     for root, dirs, files in os.walk(top_path):
+        if root.endswith("__pycache__"):
+            continue
         for file_name in files:
             file_path = os.path.join(root, file_name)
             relative_path = os.path.relpath(file_path, top_path)

--- a/hash.py
+++ b/hash.py
@@ -56,6 +56,8 @@ def list_files(top_path):
     results = []
 
     for root, dirs, files in os.walk(top_path):
+        if root.endswith("__pycache__"):
+            continue
         for file_name in files:
             results.append(os.path.join(root, file_name))
 


### PR DESCRIPTION
This PR specifically excludes the content of `__pycache__` folders.

A more generic approach would be to add an `exclude` parameter like suggested in https://github.com/claranet/terraform-aws-lambda/issues/65 but given this terraform module is really python centric, it's probably not worth it.

Note: the well maintained community module has a `patterns` parameter that fits all use cases: https://github.com/terraform-aws-modules/terraform-aws-lambda